### PR TITLE
Changes to enable compilation with Windows MSVC

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -91,7 +91,7 @@ uvc_error_t uvc_parse_vs_input_header(uvc_streaming_interface_t *stream_if,
 				      const unsigned char *block,
 				      size_t block_size);
 
-void _uvc_status_callback(struct libusb_transfer *transfer);
+void LIBUSB_CALL _uvc_status_callback(struct libusb_transfer *transfer);
 
 /** @internal
  * @brief Test whether the specified USB device has been opened as a UVC device
@@ -1513,7 +1513,7 @@ void uvc_process_status_xfer(uvc_device_handle_t *devh, struct libusb_transfer *
 /** @internal
  * @brief Process asynchronous status updates from the device.
  */
-void _uvc_status_callback(struct libusb_transfer *transfer) {
+void LIBUSB_CALL _uvc_status_callback(struct libusb_transfer *transfer) {
   UVC_ENTER();
 
   uvc_device_handle_t *devh = (uvc_device_handle_t *) transfer->user_data;

--- a/src/frame.c
+++ b/src/frame.c
@@ -67,7 +67,7 @@ uvc_frame_t *uvc_allocate_frame(size_t data_bytes) {
   if (!frame)
     return NULL;
 
-  bzero(frame, sizeof(*frame));
+  memset(frame, 0, sizeof(*frame));
 
   frame->library_owns_data = 1;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -39,6 +39,32 @@
 #include "libuvc/libuvc.h"
 #include "libuvc/libuvc_internal.h"
 
+#ifdef _MSC_VER
+
+#define DELTA_EPOCH_IN_MICROSECS  116444736000000000Ui64
+
+// gettimeofday - get time of day for Windows;
+// A gettimeofday implementation for Microsoft Windows;
+// Public domain code, author "ponnada";
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    FILETIME ft;
+    unsigned __int64 tmpres = 0;
+    static int tzflag = 0;
+    if (NULL != tv)
+    {
+        GetSystemTimeAsFileTime(&ft);
+        tmpres |= ft.dwHighDateTime;
+        tmpres <<= 32;
+        tmpres |= ft.dwLowDateTime;
+        tmpres /= 10;
+        tmpres -= DELTA_EPOCH_IN_MICROSECS;
+        tv->tv_sec = (long)(tmpres / 1000000UL);
+        tv->tv_usec = (long)(tmpres % 1000000UL);
+    }
+    return 0;
+}
+#endif // _MSC_VER
 uvc_frame_desc_t *uvc_find_frame_desc_stream(uvc_stream_handle_t *strmh,
     uint16_t format_id, uint16_t frame_id);
 uvc_frame_desc_t *uvc_find_frame_desc(uvc_device_handle_t *devh,

--- a/src/stream.c
+++ b/src/stream.c
@@ -546,7 +546,7 @@ void _uvc_process_payload(uvc_stream_handle_t *strmh, uint8_t *payload, size_t p
  *
  * @param transfer Active transfer
  */
-void _uvc_stream_callback(struct libusb_transfer *transfer) {
+void LIBUSB_CALL _uvc_stream_callback(struct libusb_transfer *transfer) {
   uvc_stream_handle_t *strmh = transfer->user_data;
 
   int resubmit = 1;

--- a/src/stream.c
+++ b/src/stream.c
@@ -147,7 +147,7 @@ uvc_error_t uvc_query_stream_ctrl(
   size_t len;
   uvc_error_t err;
 
-  bzero(buf, sizeof(buf));
+  memset(buf, 0, sizeof(buf));
 
   if (devh->info->ctrl_if.bcdUVC >= 0x0110)
     len = 34;

--- a/src/stream.c
+++ b/src/stream.c
@@ -81,11 +81,11 @@ struct format_table_entry {
 };
 
 struct format_table_entry *_get_format_entry(enum uvc_frame_format format) {
-  #define ABS_FMT(_fmt, ...) \
+  #define ABS_FMT(_fmt, _num, ...) \
     case _fmt: { \
     static enum uvc_frame_format _fmt##_children[] = __VA_ARGS__; \
     static struct format_table_entry _fmt##_entry = { \
-      _fmt, 0, {}, ARRAYSIZE(_fmt##_children), _fmt##_children }; \
+      _fmt, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}, _num, _fmt##_children }; \
     return &_fmt##_entry; }
 
   #define FMT(_fmt, ...) \
@@ -96,10 +96,10 @@ struct format_table_entry *_get_format_entry(enum uvc_frame_format format) {
 
   switch(format) {
     /* Define new formats here */
-    ABS_FMT(UVC_FRAME_FORMAT_ANY,
+    ABS_FMT(UVC_FRAME_FORMAT_ANY, 2,
       {UVC_FRAME_FORMAT_UNCOMPRESSED, UVC_FRAME_FORMAT_COMPRESSED})
 
-    ABS_FMT(UVC_FRAME_FORMAT_UNCOMPRESSED,
+    ABS_FMT(UVC_FRAME_FORMAT_UNCOMPRESSED, 3,
       {UVC_FRAME_FORMAT_YUYV, UVC_FRAME_FORMAT_UYVY, UVC_FRAME_FORMAT_GRAY8})
     FMT(UVC_FRAME_FORMAT_YUYV,
       {'Y',  'U',  'Y',  '2', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
@@ -110,7 +110,7 @@ struct format_table_entry *_get_format_entry(enum uvc_frame_format format) {
     FMT(UVC_FRAME_FORMAT_BY8,
       {'B',  'Y',  '8',  ' ', 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71})
 
-    ABS_FMT(UVC_FRAME_FORMAT_COMPRESSED,
+    ABS_FMT(UVC_FRAME_FORMAT_COMPRESSED, 1,
       {UVC_FRAME_FORMAT_MJPEG})
     FMT(UVC_FRAME_FORMAT_MJPEG,
       {'M',  'J',  'P',  'G'})


### PR DESCRIPTION
A port of libusb exists for Windows, and these changes allow libuvc to compile with MSVC on Windows. I've not actually managed get a camera running with libuvc on Windows, but I think it should be possible with some setup.