### PR TITLE
Mac deadlock fix

### DIFF
--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -212,7 +212,11 @@ typedef struct uvc_device_info {
   We could/should change this to allow reduce it to, say, 5 by default
   and then allow the user to change the number of buffers as required.
  */
+#ifdef __APPLE__
+#define LIBUVC_NUM_TRANSFER_BUFS 8
+#else
 #define LIBUVC_NUM_TRANSFER_BUFS 100
+#endif
 
 #define LIBUVC_XFER_BUF_SIZE	( 16 * 1024 * 1024 )
 
@@ -226,7 +230,7 @@ struct uvc_stream_handle {
   /** Current control block */
   struct uvc_stream_ctrl cur_ctrl;
 
-  /* listeners may only access hold*, and only when holding a 
+  /* listeners may only access hold*, and only when holding a
    * lock on cb_mutex (probably signaled with cb_cond) */
   uint8_t fid;
   uint32_t seq, hold_seq;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1175,7 +1175,7 @@ uvc_error_t uvc_stream_stop(uvc_stream_handle_t *strmh) {
   for(i=0; i < LIBUVC_NUM_TRANSFER_BUFS; i++) {
     if(strmh->transfers[i] != NULL) {
       int res = libusb_cancel_transfer(strmh->transfers[i]);
-      if(res < 0 && res != LIBUSB_ERROR_NOT_FOUND ) {
+      if(res < 0) {
         free(strmh->transfers[i]->buffer);
         libusb_free_transfer(strmh->transfers[i]);
         strmh->transfers[i] = NULL;


### PR DESCRIPTION
This appears to fix https://github.com/ktossell/libuvc/issues/16 .

The hang is due to a deadlock at https://github.com/ktossell/libuvc/blob/master/src/stream.c#L1194 . This happens because completed transfers (with status of LIBUSB_ERROR_NOT_FOUND) still have a valid buffer and pointer, and these have to be cleared, or the function will deadlock later. As the transfers are completed, the callback function will not clean them up.

The number of buffers had to be reduced to avoid failure on start — 100 16MiB buffers is excessive already, and causes problems on OS X. Reducing this to 8 helps. libfreenect2 had a similar issue which had the same solution — see https://github.com/OpenKinect/libfreenect2/pull/435 and https://github.com/OpenKinect/libfreenect2/commit/cdeb07917c3431abf530785c151c9656f1c26d3a.