### PR TITLE
Build fix for Chromium

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,8 @@ set(libuvc_VERSION_MINOR 0)
 set(libuvc_VERSION_PATCH 5)
 set(libuvc_VERSION ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH})
 
-find_library(LIBUSB_LIBRARY_NAMES usb-1.0
-	PATHS /opt/local/lib)
-
-find_path(LIBUSB_INCLUDE_DIR libusb-1.0/libusb.h
-	PATHS /opt/local/include)
+find_package(PkgConfig)
+pkg_check_modules(LIBUSB libusb-1.0)
 
 # Try to find JPEG using a module or pkg-config. If that doesn't work, search for the header.
 find_package(jpeg QUIET)
@@ -44,7 +41,7 @@ SET(SOURCES src/ctrl.c src/ctrl-gen.c src/device.c src/diag.c
 include_directories(
   ${libuvc_SOURCE_DIR}/include
   ${libuvc_BINARY_DIR}/include
-  ${LIBUSB_INCLUDE_DIR}
+  ${LIBUSB_INCLUDE_DIRS}
 )
 
 if(JPEG_FOUND)
@@ -74,10 +71,10 @@ if(JPEG_FOUND)
   target_link_libraries (uvc ${JPEG_LIBRARIES})
 endif(JPEG_FOUND)
 
-target_link_libraries(uvc ${LIBUSB_LIBRARY_NAMES})
+target_link_libraries(uvc ${LIBUSB_LIBRARIES})
 
 #add_executable(test src/test.c)
-#target_link_libraries(test uvc ${LIBUSB_LIBRARY_NAMES} opencv_highgui
+#target_link_libraries(test uvc ${LIBUSB_LIBRARIES} opencv_highgui
 #  opencv_core)
 
 install(TARGETS uvc

--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 #include <stdio.h> // FILE
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <libuvc/libuvc_config.h>
 
 /** UVC error types, based on libusb errors


### PR DESCRIPTION
Some platforms use different version of libusb. For instance, Chromium compiles
libusb by itself. So hard coding of libuse version (i.e. <libusb-1.0/libusb.h>) causes
compile failure.