### PR TITLE
Fix the first captured image being dropped

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -825,7 +825,7 @@ uvc_error_t uvc_stream_start(
   }
 
   strmh->running = 1;
-  strmh->seq = 0;
+  strmh->seq = 1;
   strmh->fid = 0;
   strmh->pts = 0;
   strmh->last_scr = 0;


### PR DESCRIPTION
The first frame generated by any camera was always lost in the libuvc
layer, and not passed on to the listening application.

The start value of seq (thus hold_seq) could be arbitrary, but it must
be non-zero.  Both the callback listener and the polling function's
last_seq / last_polled_seq start initialised to zero, which causes any
image with hold_seq zero to be ignored.