### PR TITLE
Remove libusb.h from the public header

### DIFF
--- a/include/libuvc/libuvc.h
+++ b/include/libuvc/libuvc.h
@@ -6,8 +6,12 @@ extern "C" {
 #endif
 
 #include <stdio.h> // FILE
-#include <libusb.h>
+#include <stdint.h>
+#include <sys/time.h>
 #include <libuvc/libuvc_config.h>
+
+struct libusb_context;
+struct libusb_device_handle;
 
 /** UVC error types, based on libusb errors
  * @ingroup diag
@@ -500,7 +504,7 @@ uvc_error_t uvc_open(
 void uvc_close(uvc_device_handle_t *devh);
 
 uvc_device_t *uvc_get_device(uvc_device_handle_t *devh);
-libusb_device_handle *uvc_get_libusb_handle(uvc_device_handle_t *devh);
+struct libusb_device_handle *uvc_get_libusb_handle(uvc_device_handle_t *devh);
 
 void uvc_ref_device(uvc_device_t *dev);
 void uvc_unref_device(uvc_device_t *dev);

--- a/include/libuvc/libuvc_internal.h
+++ b/include/libuvc/libuvc_internal.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <signal.h>
+#include <libusb.h>
 #include "utlist.h"
 
 /** Converts an unaligned four-byte little-endian integer into an int32 */


### PR DESCRIPTION
This should fix the include path problems seen when including libuvc.h into other programs following #48.