### PR TITLE
Remove unused variables

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -561,7 +561,6 @@ void uvc_free_device_descriptor(
 uvc_error_t uvc_get_device_list(
     uvc_context_t *ctx,
     uvc_device_t ***list) {
-  uvc_error_t ret;
   struct libusb_device **usb_dev_list;
   struct libusb_device *usb_dev;
   int num_usb_devices;
@@ -571,7 +570,6 @@ uvc_error_t uvc_get_device_list(
 
   /* per device */
   int dev_idx;
-  struct libusb_device_handle *usb_devh;
   struct libusb_config_descriptor *config;
   struct libusb_device_descriptor desc;
   uint8_t got_interface;
@@ -600,7 +598,6 @@ uvc_error_t uvc_get_device_list(
   dev_idx = -1;
 
   while ((usb_dev = usb_dev_list[++dev_idx]) != NULL) {
-    usb_devh = NULL;
     got_interface = 0;
 
     if (libusb_get_config_descriptor(usb_dev, 0, &config) != 0)
@@ -1082,7 +1079,6 @@ uvc_error_t uvc_parse_vc_selector_unit(uvc_device_t *dev,
 					 uvc_device_info_t *info,
 					 const unsigned char *block, size_t block_size) {
   uvc_selector_unit_t *unit;
-  size_t i;
 
   UVC_ENTER();
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -482,7 +482,6 @@ void _uvc_process_payload(uvc_stream_handle_t *strmh, uint8_t *payload, size_t p
   size_t header_len;
   uint8_t header_info;
   size_t data_len;
-  struct libusb_iso_packet_descriptor *pkt;
 
   /* magic numbers for identifying header packets from some iSight cameras */
   static uint8_t isight_tag[] = {
@@ -1031,7 +1030,6 @@ void *_uvc_user_caller(void *arg) {
  * must be called with stream cb lock held!
  */
 void _uvc_populate_frame(uvc_stream_handle_t *strmh) {
-  size_t alloc_size = strmh->cur_ctrl.dwMaxVideoFrameSize;
   uvc_frame_t *frame = &strmh->frame;
   uvc_frame_desc_t *frame_desc;
 


### PR DESCRIPTION
The dwMaxVideoFrameSize was never used, the others appear to have
been used by code that has since been refactored.