### PR TITLE
use soversion for shared libraries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# make sure that .gitignore, .travis.yml,... are not part of a
+# source-package generated via 'git archive'
+.git*      	export-ignore
+/.*		export-ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 
 if(BUILD_UVC_SHARED)
   add_library(uvc SHARED ${SOURCES})
+  set_property(TARGET uvc PROPERTY VERSION ${libuvc_VERSION} )
+  set_property(TARGET uvc PROPERTY SOVERSION ${libuvc_VERSION_MAJOR} )
   list(APPEND UVC_TARGETS uvc)
 endif()
 

--- a/include/libuvc/libuvc_config.h.in
+++ b/include/libuvc/libuvc_config.h.in
@@ -11,7 +11,7 @@
    (@libuvc_VERSION_PATCH@))
 
 /** @brief Test whether libuvc is new enough
- * This macro evaluates true iff the current version is
+ * This macro evaluates true if the current version is
  * at least as new as the version specified.
  */
 #define LIBUVC_VERSION_GTE(major, minor, patch)                         \


### PR DESCRIPTION
while packaging libuvc for Debian, I noticed that the library name doesn't use a soversion, and thus fails to use [semantic versioning](http://semver.org/).

please use a semantic versioning scheme for libuvc, it makes dynamic linking so much easier (esp. in the context of an OS distribution).
the PR adds initial support for semver, but uses the release version as the library soversion.
please note that the two versions need not be coupled together (the soversion usually increases much more slowly than the semver).

the PR also adds a `.gitattributes` file to exclude repository housekeeping files (like `.gitignore` or the configuration for CI services integrated into github) from the release tarball that can be downloaded via the "tag/releases" tab (which internally uses `git archive`)